### PR TITLE
Update example attacher and provisioner yaml file to use headless service

### DIFF
--- a/deploy/kubernetes/attacher.yaml
+++ b/deploy/kubernetes/attacher.yaml
@@ -55,10 +55,7 @@ metadata:
 spec:
   selector:
     app: csi-attacher
-  ports:
-    - name: dummy
-      port: 12345
-
+  clusterIP: None
 ---
 
 kind: StatefulSet

--- a/deploy/kubernetes/provisioner.yaml
+++ b/deploy/kubernetes/provisioner.yaml
@@ -55,10 +55,7 @@ metadata:
 spec:
   selector:
     app: csi-provisioner
-  ports:
-    - name: dummy
-      port: 12345
-
+  clusterIP: None
 ---
 
 kind: StatefulSet


### PR DESCRIPTION
Fixes: #11 

Tested on my EKS cluster that example app is deployed after recreate attacher/provisioner service as headless. 